### PR TITLE
feat: support input from stdin

### DIFF
--- a/klepcbgenmod.py
+++ b/klepcbgenmod.py
@@ -176,8 +176,11 @@ class KLEPCBGenerator:
 
         print("Reading input file '" + args.infile + "' ...")
 
-        with open(args.infile, "r", encoding="latin-1") as read_file:
-            kle_json = json.load(read_file)
+        if args.infile == "-":
+            kle_json = json.load(sys.stdin)
+        else:
+            with open(args.infile, "r", encoding="latin-1") as read_file:
+                kle_json = json.load(read_file)
 
         # First create a list of switches, each with its own X,Y coordinate
         current_x = 0.0


### PR DESCRIPTION
If the infile input is a `-`, read the json input from stdin instead of a file.