### PR TITLE
Fix incorrect schematic files

### DIFF
--- a/klepcbgenmod.py
+++ b/klepcbgenmod.py
@@ -302,7 +302,7 @@ class KLEPCBGenerator:
                     author=self.keyboard.author,
                     date=now,
                     comment=comment,
-                )
+                ).replace("\n\n", "\n")
             )
 
     def place_layout_components(self):


### PR DESCRIPTION
For some reason, the schematic (.sch) files are usually wrong,
having one blank line inserted quite randomly that prevents
kicad from opening the file.

To fix this, it is enough to just open the file with a text
editor and remove that blank line.

This patch does this automagically, thus ensuring that the
schematic files are correct.