### PR TITLE
Add support for hot-swap sockets

### DIFF
--- a/klepcbgen.py
+++ b/klepcbgen.py
@@ -38,6 +38,11 @@ a keyboard designed using the Keyboard Layout Editor \
     )
 
     parser.add_argument(
+        "--hotswap", dest="hotswap", action="store_true",
+        help='Generate pads for Kailh hotswap sockets'
+    )
+
+    parser.add_argument(
         "infile",
         help="A JSON file containing a keyboard layout in the KLE JSON format",
     )
@@ -50,5 +55,5 @@ a keyboard designed using the Keyboard Layout Editor \
 if __name__ == "__main__":
     arguments = parse_command_line_arguments()
     kbpcbgen = KLEPCBGenerator()
-    kbpcbgen.generate_kicadproject(arguments.infile, arguments.outname, arguments.routing, arguments.colgroup)
+    kbpcbgen.generate_kicadproject(arguments.infile, arguments.outname, arguments.routing, arguments.colgroup, arguments.hotswap)
     kbpcbgen.keyboard.print_key_info()

--- a/templates/layout/keyswitch.tpl
+++ b/templates/layout/keyswitch.tpl
@@ -31,10 +31,19 @@
     (pad "" np_thru_hole circle (at 2.54 5.08) (size 1.7 1.7) (drill 1.7) (layers *.Cu *.Mask))
     (pad "" np_thru_hole circle (at -7.62 5.08) (size 1.7 1.7) (drill 1.7) (layers *.Cu *.Mask))
     (pad "" np_thru_hole circle (at -2.54 5.08) (size 4 4) (drill 4) (layers *.Cu *.Mask))
+{% if not hotswap %}
     (pad 2 thru_hole circle (at -6.35 2.54) (size 2.2 2.2) (drill 1.5) (layers *.Cu *.Mask)
       (net {{diodenetnum}} {{diodenetname}}))
     (pad 1 thru_hole circle (at 0 0) (size 2.2 2.2) (drill 1.5) (layers *.Cu *.Mask)
       (net {{colnetnum}} {{colnetname}}))
+{% else %}
+    (pad 2 smd rect (at -9.9 2.54) (size 2.55 2.5) (layers B.Cu B.Paste B.Mask)
+      (net {{diodenetnum}} {{diodenetname}}))
+    (pad "" np_thru_hole circle (at -6.35 2.54) (size 3.2 3.2) (drill 3.2) (layers *.Cu *.Mask))
+    (pad 1 smd rect (at 3.55 0) (size 2.55 2.5) (layers B.Cu B.Paste B.Mask)
+      (net {{colnetnum}} {{colnetname}}))
+    (pad "" np_thru_hole circle (at 0 0) (size 3.2 3.2) (drill 3.2) (layers *.Cu *.Mask))
+{% endif %}
     (model ${KISYS3DMOD}/Button_Switch_Keyboard.3dshapes/SW_Cherry_MX_{{keywidth}}u_PCB.wrl
       (at (xyz 0 0 0))
       (scale (xyz 1 1 1))

--- a/templates/layout/via.tpl
+++ b/templates/layout/via.tpl
@@ -1,1 +1,1 @@
-  (via (at {{x}} {{y}}) (size 0.8) (drill 0.4) (layers F.Cu B.Cu) (net {{netnum}}))
+  (via (at {{x}} {{y}}) (size 0.75) (drill 0.4) (layers {{layers}}) (net {{netnum}}))


### PR DESCRIPTION
Without much changes to routing it is feasible to alter the footprint of a switch to use Kailh hot-swap sockets.